### PR TITLE
Remove Node 18 workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
- remove Node 18 from the GitHub Actions test matrix so only Node 20 is used

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684855ad6158832c8caabe116b1ad608